### PR TITLE
0xFF を読んだ際の意図しない振る舞いを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .gradle/
 .settings/
 bin/
+build
+*~

--- a/README.md
+++ b/README.md
@@ -19,3 +19,6 @@ $ java -jar build/libs/simple-http-server.jar
 $ gradle check
 ```
 
+## Document
+
+1: @opengl-8080[2017] 簡単なHTTPサーバーを作る(https://qiita.com/opengl-8080/items/ca152658a0e52c786029)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # simple-http-server
+
+## build
+
+build (and test)
+```shell
+$ gradle build
+```
+
+## run
+
+```shell
+$ java -jar build/libs/simple-http-server.jar
+```
+
+## testing
+
+```shell
+$ gradle check
+```
+

--- a/build.gradle
+++ b/build.gradle
@@ -14,3 +14,9 @@ dependencies {
     testCompile 'junit:junit:4.12', {transitive = false}
     testCompile 'org.hamcrest:hamcrest-all:1.3'
 }
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'gl8080.http.Main'
+    }
+}

--- a/src/main/java/gl8080/http/IOUtil.java
+++ b/src/main/java/gl8080/http/IOUtil.java
@@ -32,28 +32,27 @@ public class IOUtil {
         List<Byte> list = new ArrayList<>();
         
         while (true) {
-            int c = in.read();
+            int b = in.read();
             
-            if (c == -1) {
+            if (b == -1) {
                 throw new EmptyRequestException();
             }
             
-            list.add((byte)c);
+            list.add((byte)b);
             
             int size = list.size();
             if (2 <= size) {
-                byte cr = list.get(size - 2).byteValue();
-                byte lf = list.get(size - 1).byteValue();
+                char cr = (char)list.get(size - 2).byteValue();
+                char lf = (char)list.get(size - 1).byteValue();
                 
                 if (cr == '\r' && lf == '\n') {
                     break;
                 }
             }
         }
-
-        // copy to byte array except tailing CRLF
-        byte[] buffer = new byte[list.size() - 2]; 
-        for (int i = 0; i < buffer.length; i++) {
+        
+        byte[] buffer = new byte[list.size() - 2]; // CRLF の分減らす
+        for (int i = 0; i < list.size() - 2; i++) {
             buffer[i] = list.get(i);
         }
         

--- a/src/main/java/gl8080/http/IOUtil.java
+++ b/src/main/java/gl8080/http/IOUtil.java
@@ -32,27 +32,28 @@ public class IOUtil {
         List<Byte> list = new ArrayList<>();
         
         while (true) {
-            byte b = (byte)in.read();
+            int c = in.read();
             
-            if (b == -1) {
+            if (c == -1) {
                 throw new EmptyRequestException();
             }
             
-            list.add(b);
+            list.add((byte)c);
             
             int size = list.size();
             if (2 <= size) {
-                char cr = (char)list.get(size - 2).byteValue();
-                char lf = (char)list.get(size - 1).byteValue();
+                byte cr = list.get(size - 2).byteValue();
+                byte lf = list.get(size - 1).byteValue();
                 
                 if (cr == '\r' && lf == '\n') {
                     break;
                 }
             }
         }
-        
-        byte[] buffer = new byte[list.size() - 2]; // CRLF の分減らす
-        for (int i = 0; i < list.size() - 2; i++) {
+
+        // copy to byte array except tailing CRLF
+        byte[] buffer = new byte[list.size() - 2]; 
+        for (int i = 0; i < buffer.length; i++) {
             buffer[i] = list.get(i);
         }
         

--- a/src/main/java/gl8080/http/Main.java
+++ b/src/main/java/gl8080/http/Main.java
@@ -4,8 +4,13 @@ public class Main {
     
     public static void main(String[] args) throws Exception {
         System.out.println("start >>>");
+
+	int port = 80;
+	if (args.length == 1) {
+	    port = Integer.valueOf(args[0]);
+	}
         
-        SimpleHttpServer server = new SimpleHttpServer();
+        SimpleHttpServer server = new SimpleHttpServer(port);
         server.start();
     }
 }

--- a/src/main/java/gl8080/http/SimpleHttpServer.java
+++ b/src/main/java/gl8080/http/SimpleHttpServer.java
@@ -11,11 +11,16 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class SimpleHttpServer {
-    
+
+    private int port;
     private ExecutorService service = Executors.newCachedThreadPool();
+
+    public SimpleHttpServer(int port) {
+	this.port = port;
+    }
     
     public void start() {
-        try (ServerSocket server = new ServerSocket(80)) {
+        try (ServerSocket server = new ServerSocket(port)) {
             while (true) {
                 this.serverProcess(server);
             }

--- a/src/test/java/gl8080/http/IOUtilTest.java
+++ b/src/test/java/gl8080/http/IOUtilTest.java
@@ -78,5 +78,11 @@ public class IOUtilTest {
 	InputStream in = new ByteArrayInputStream(bytes);
 	String str = IOUtil.readLine(in);
     }
+
+    @Test
+    public void castIntToByte() {
+	byte b = (byte)0xFF;
+	assertEquals(-1, b);	
+    }
 }
 

--- a/src/test/java/gl8080/http/IOUtilTest.java
+++ b/src/test/java/gl8080/http/IOUtilTest.java
@@ -1,0 +1,96 @@
+package gl8080.http;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class IOUtilTest {
+
+    @Test
+    public void readLine() throws Exception {
+	byte[] bytes = { 'a', '\r', '\n' };
+	InputStream in = new ByteArrayInputStream(bytes);
+	String str = IOUtil.readLine(in);
+	assertThat("a", is(str));
+    }
+
+    //    @Test
+    public void readLine2() throws Exception {
+	byte[] bytes = { -1, '\r', '\n' };
+	InputStream in = new ByteArrayInputStream(bytes);
+	String str = IOUtil.readLine(in);
+    }
+    
+    @Test(expected = EmptyRequestException.class)
+    public void tryEmptyRequest() throws Exception {    
+	byte[] bytes = { };
+	InputStream in = new ByteArrayInputStream(bytes);
+	String str = IOUtil.readLine(in);
+    }
+
+
+    /*
+     * Another Impl of IOUtil.readLine()
+     */
+    public static String readLine(InputStream in) throws IOException {
+        List<Byte> list = new ArrayList<>();
+
+	int c, prev_c = -1;
+        while (true) {
+	    c = in.read();
+	    if (c == -1) {
+		throw new EmptyRequestException();
+	    }
+	    
+	    if (prev_c == '\r' && c == '\n') {
+		list.remove(list.size() - 1); // remove tailing '\r'
+		break;
+	    }
+	    
+            list.add((byte)c);	    
+	    prev_c = c;
+        }
+
+	byte[] buffer = new byte[list.size()];
+	for (int i = 0; i < list.size(); i++) {
+	    buffer[i] = list.get(i);
+	}
+	
+        return new String(buffer);
+    }
+
+    //
+    // Testing for the another Impl of IOUtil.readLine()
+    //
+    
+    @Test
+    public void readLine2_1() throws Exception {
+	byte[] bytes = { 'a', '\r', '\n' };
+	InputStream in = new ByteArrayInputStream(bytes);
+	String str = IOUtilTest.readLine(in);
+	assertThat("a", is(str));
+    }
+
+    @Test
+    public void readLine2_2() throws Exception {
+	byte[] bytes = { -1, '\r', '\n' };
+	InputStream in = new ByteArrayInputStream(bytes);
+	String str = IOUtilTest.readLine(in);
+    }
+    
+    @Test(expected = EmptyRequestException.class)
+    public void tryEmptyRequest2() throws Exception {    
+	byte[] bytes = { };
+	InputStream in = new ByteArrayInputStream(bytes);
+	String str = IOUtilTest.readLine(in);
+    }
+    
+}
+

--- a/src/test/java/gl8080/http/IOUtilTest.java
+++ b/src/test/java/gl8080/http/IOUtilTest.java
@@ -13,84 +13,70 @@ import org.junit.Test;
 
 public class IOUtilTest {
 
+    /**
+     * readline() normal testing
+     */ 
     @Test
-    public void readLine() throws Exception {
-	byte[] bytes = { 'a', '\r', '\n' };
+    public void readLineN() throws Exception {
+	byte[] bytes = "GET / HTTP/1.1\r\n".getBytes();
 	InputStream in = new ByteArrayInputStream(bytes);
 	String str = IOUtil.readLine(in);
-	assertThat("a", is(str));
+	assertThat("GET / HTTP/1.1", is(str));
     }
-
-    //    @Test
-    public void readLine2() throws Exception {
-	byte[] bytes = { -1, '\r', '\n' };
-	InputStream in = new ByteArrayInputStream(bytes);
-	String str = IOUtil.readLine(in);
-    }
-    
-    @Test(expected = EmptyRequestException.class)
-    public void tryEmptyRequest() throws Exception {    
-	byte[] bytes = { };
-	InputStream in = new ByteArrayInputStream(bytes);
-	String str = IOUtil.readLine(in);
-    }
-
 
     /*
-     * Another Impl of IOUtil.readLine()
+     * readLine() reads data includes isolated CR and LF.
      */
-    public static String readLine(InputStream in) throws IOException {
-        List<Byte> list = new ArrayList<>();
-
-	int c, prev_c = -1;
-        while (true) {
-	    c = in.read();
-	    if (c == -1) {
-		throw new EmptyRequestException();
-	    }
-	    
-	    if (prev_c == '\r' && c == '\n') {
-		list.remove(list.size() - 1); // remove tailing '\r'
-		break;
-	    }
-	    
-            list.add((byte)c);	    
-	    prev_c = c;
-        }
-
-	byte[] buffer = new byte[list.size()];
-	for (int i = 0; i < list.size(); i++) {
-	    buffer[i] = list.get(i);
-	}
-	
-        return new String(buffer);
+    @Test
+    public void isolatedCRandLF() throws Exception {    
+	byte[] bytes = "include isolated \r and \n\r\n".getBytes();
+	InputStream in = new ByteArrayInputStream(bytes);
+	String str = IOUtil.readLine(in);
+	assertThat("include isolated \r and \n", is(str));
     }
 
-    //
-    // Testing for the another Impl of IOUtil.readLine()
-    //
-    
+    /**
+     * readline() boundary testing 0
+     */ 
     @Test
-    public void readLine2_1() throws Exception {
-	byte[] bytes = { 'a', '\r', '\n' };
+    public void readLineB0() throws Exception {
+	byte[] bytes = "\r\n".getBytes();
 	InputStream in = new ByteArrayInputStream(bytes);
-	String str = IOUtilTest.readLine(in);
-	assertThat("a", is(str));
+	String str = IOUtil.readLine(in);
+	assertThat("", is(str));
     }
 
+    /**
+     * readline() boundary testing 1
+     */ 
     @Test
-    public void readLine2_2() throws Exception {
-	byte[] bytes = { -1, '\r', '\n' };
+    public void readLineB1() throws Exception {
+	byte[] bytes = "A\r\n".getBytes();
 	InputStream in = new ByteArrayInputStream(bytes);
-	String str = IOUtilTest.readLine(in);
+	String str = IOUtil.readLine(in);
+	assertThat("A", is(str));
     }
     
+    /**
+     * readLine() can reads 0xFF(-1) as not EOF but data.
+     * without throwing EmptyRequestException. 
+     */
+    @Test
+    public void readLine2() throws Exception {
+	byte[] bytes = { (byte)0xFF, '\r', '\n' };
+	InputStream in = new ByteArrayInputStream(bytes);
+	String str = IOUtil.readLine(in);
+    }
+    
+    /*
+     * readLine() reads empty byte stream then throw
+     * EmptyRequestException.
+     */
     @Test(expected = EmptyRequestException.class)
-    public void tryEmptyRequest2() throws Exception {    
-	byte[] bytes = { };
+    public void throwEmptyRequest() throws Exception {    
+	byte[] bytes = { }; 
 	InputStream in = new ByteArrayInputStream(bytes);
-	String str = IOUtilTest.readLine(in);
+	String str = IOUtil.readLine(in);
     }
-    
 }
 


### PR DESCRIPTION
IOUtil#readLine() にてin.read() から 0xFF を返された場合に、処理が終了してしまうという振る舞いは意図されたものでないと考えます。

in.read() の返り値をint から byte にキャストする前に EOF との比較を行うように変更しました。